### PR TITLE
76 remove embedded generation

### DIFF
--- a/common/parsers.ts
+++ b/common/parsers.ts
@@ -367,6 +367,11 @@ export const groupByUnitGroup = (x: t.BmUnitValues): t.UnitGroupLevel[] => {
   return output;
 };
 
+type GroupByFuelTypeAndInterconnectorsParams = {
+  x: t.UnitGroupLevel[];
+  includeEmbedded: boolean;
+}
+
 /*
 Group by fuel type
 
@@ -374,9 +379,9 @@ Group the output of groupByUnitGroup by fuel type
 includeEmedded will include embedded wind and solar units
 default false as total data on these is sourced separately from NG ESO.
 */
-export const groupByFuelTypeAndInterconnectors = (
-  x: t.UnitGroupLevel[],
-  includeEmbedded: boolean = false
+export const groupByFuelTypeAndInterconnectors = ({
+  x, includeEmbedded
+}: GroupByFuelTypeAndInterconnectorsParams
 ): t.FuelTypeLevel[] => {
   log.debug(`groupByFuelType`);
   let output: t.FuelTypeLevel[] = [];

--- a/services/log.ts
+++ b/services/log.ts
@@ -2,7 +2,7 @@
 
 export const log = {
     debug: (msg: string) => {
-        // console.log(msg)
+        console.log(msg)
     },
     info: (msg: string) => console.log(msg),
     error: (err: Error) => console.error(err),

--- a/services/log.ts
+++ b/services/log.ts
@@ -2,7 +2,7 @@
 
 export const log = {
     debug: (msg: string) => {
-        console.log(msg)
+        // console.log(msg)
     },
     info: (msg: string) => console.log(msg),
     error: (err: Error) => console.error(err),


### PR DESCRIPTION
Solution changed from original plan.
NG ESO Api is unreliable, so it is allowed to fail, in which case just the transmission data is rendered.
When NG ESO API is working, the total volume of wind which is embedded (having an E_) code is stripped out before the forecast embedded volume from NG ESO is added in.