### PR TITLE
add ForegroundComponent to dismount screens when app is in background

### DIFF
--- a/atoms/screens.tsx
+++ b/atoms/screens.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { Image, StyleSheet, View } from "react-native";
+import log from "../services/log";
+
+/*
+BackgroundScreen
+Rendered when the app is in the background.
+*/
+export const BackgroundScreen: React.FC = () => {
+  log.info(`Rendering BackgroundScreen`);
+  return (
+    <SafeAreaView style={styles.container} testID="background-screen">
+      <View
+        style={styles.imageWrapper}
+        testID="background-screen-image-wrapper"
+      >
+        <Image
+          testID="background-screen-image"
+          style={styles.image}
+          source={require("../assets/images/icon.png")}
+        />
+      </View>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    height: "100%",
+    alignItems: "center",
+  },
+  imageWrapper: { height: "50%", width: "100%" },
+  image: {
+    width: "100%",
+    height: "100%",
+    resizeMode: "contain",
+  },
+});

--- a/components/Foreground.active.test.tsx
+++ b/components/Foreground.active.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { Text } from "react-native";
+import { ForegroundComponent } from "./Foreground";
+import { render, screen } from "@testing-library/react-native";
+
+jest.mock("react-native/Libraries/AppState/AppState", () => ({
+  currentState: "active",
+  addEventListener: jest.fn(),
+}));
+
+const mockBackgroundRender = jest.fn();
+
+const MockBackgroundScreen = () => {
+    mockBackgroundRender()
+    return <Text testID='mock-background-screen'>MOCK_BACKGROUND_SCREEN</Text>
+}
+
+jest.mock("../atoms/screens", () => ({
+    BackgroundScreen: () => <MockBackgroundScreen/>
+  }));
+
+const MockChildren = () => <Text>MOCK_CHILDREN</Text>;
+
+describe("components/ForegroundComponent/forecast", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    render(
+      <ForegroundComponent>
+        <MockChildren />
+      </ForegroundComponent>
+    );
+  });
+  test("should render MockChildren when app is in foreground", () => {
+    screen.getByText("MOCK_CHILDREN");
+  });
+
+  test('mockBackgroundRender should not be called', () => {
+    expect(mockBackgroundRender).not.toHaveBeenCalled()
+  })
+});

--- a/components/Foreground.background.test.tsx
+++ b/components/Foreground.background.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Text } from "react-native";
+import { ForegroundComponent } from "./Foreground";
+import { render, screen } from "@testing-library/react-native";
+
+jest.mock("react-native/Libraries/AppState/AppState", () => ({
+  currentState: "background",
+  addEventListener: jest.fn(),
+}));
+
+const MockBackgroundScreen = () => <Text>MOCK_BACKGROUND_SCREEN</Text>;
+
+jest.mock("../atoms/screens", () => ({
+  BackgroundScreen: () => <MockBackgroundScreen/>
+}));
+
+const mockChildrenRender = jest.fn();
+
+const MockChildren = () => {
+  mockChildrenRender()
+  return <Text>MOCK_CHILDREN</Text>;
+}
+
+describe("components/ForegroundComponent/background", () => {
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    render(
+      <ForegroundComponent>
+        <MockChildren />
+      </ForegroundComponent>
+    );
+  });
+
+  test("should render MockBackgroundScreen when app is in background", () => {
+    screen.getByText("MOCK_BACKGROUND_SCREEN");
+  });
+
+  test('mockChildrenRender should not be called', () => {
+    expect(mockChildrenRender).not.toHaveBeenCalled()
+  })
+
+});

--- a/components/Foreground.tsx
+++ b/components/Foreground.tsx
@@ -1,0 +1,32 @@
+// component to dismount live components when the app is in background
+
+import React from "react";
+import { AppState } from "react-native";
+import { BackgroundScreen } from "../atoms/screens";
+import log from "../services/log";
+
+
+type ForegroundComponentProps = {
+  children: React.ReactNode;
+};
+
+/*
+ForegroundComponent
+Uses the AppState API to determine if the app is in the foreground or background.
+If in the background, renders BackgroundScreen.
+If in the foreground, renders children.
+*/
+export const ForegroundComponent: React.FC<ForegroundComponentProps> = ({
+  children,
+}) => {
+  const [appState, setAppState] = React.useState<string>(AppState.currentState);
+  React.useEffect(() => {
+    AppState.addEventListener("change", setAppState);
+  }, []);
+  if (appState !== "active") {
+    log.info(`App is in background, rendering BackgroundScreen`);
+    return <BackgroundScreen />;
+  }
+  log.info(`App is in foreground, rendering children`);
+  return <>{children}</>;
+};

--- a/components/InternetConnection.tsx
+++ b/components/InternetConnection.tsx
@@ -4,6 +4,7 @@ import { NoInternetConnectionCard } from "../atoms/cards";
 import { Refresh } from "../atoms/controls";
 import { WithLicense } from "./WithLicense";
 import { useInternetConnection } from "../services/hooks";
+import { ForegroundComponent } from "./Foreground";
 
 type InternetConnectionProps = {};
 
@@ -18,7 +19,9 @@ export const InternetConnection: React.FC<InternetConnectionProps> = () => {
       {isConnected === false && <NoInternetConnectionCard />}
       {isConnected === true && (
         <WithLicense>
-          <ExpoRoot context={ctx} />
+          <ForegroundComponent>
+            <ExpoRoot context={ctx} />
+          </ForegroundComponent>
         </WithLicense>
       )}
     </>


### PR DESCRIPTION
Ensures that main screens are not rendered when the app is in background
A full re-render will be required whenever the app is resumed and re-enters the foreground.
Should hopefully prevent errors that currently can occur when this happens